### PR TITLE
Add MathJax support

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,7 @@
     <script src="/js/skel.min.js"></script>
     <script src="/js/skel-layers.min.js"></script>
     <script src="/js/init.js"></script>
+    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
     <noscript>
         <link rel="stylesheet" href="/css/skel.css" />
         <link rel="stylesheet" href="/css/style.css" />


### PR DESCRIPTION
MathJax supports Latex-like equations/math in Markdown posts. We, obviously, need this feature on ScienceHub
